### PR TITLE
Handling errors when previewing the theme locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,9 @@ gem "github-pages", group: :jekyll_plugins
 
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"
+
+# https://github.com/jekyll/jekyll/issues/8523#issuecomment-751409319
+# When running locally, we run into the following error —
+# `require': cannot load such file -- webrick (LoadError)
+# adding this avoids it
+gem "webrick"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@
 source "https://rubygems.org"
 
 gemspec
-gem "github-pages", group: :jekyll_plugins
+# commenting below to remove dependency with "github-pages" 
+# gem "github-pages", group: :jekyll_plugins
 
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"
@@ -13,3 +14,7 @@ gem "jekyll-sitemap"
 # `require': cannot load such file -- webrick (LoadError)
 # adding this avoids it
 gem "webrick"
+
+# adding the following gems to support removal of "github-pages" dependency
+gem "jemoji"
+gem "kramdown-parser-gfm"

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,9 @@ sidebar:
   - name: Project Repository
     icon: <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img" style="vertical-align:-0.125em;" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 16 16"><g fill="currentColor"><path d="M12.643 15C13.979 15 15 13.845 15 12.5V5H1v7.5C1 13.845 2.021 15 3.357 15h9.286zM5.5 7h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1 0-1zM.8 1a.8.8 0 0 0-.8.8V3a.8.8 0 0 0 .8.8h14.4A.8.8 0 0 0 16 3V1.8a.8.8 0 0 0-.8-.8H.8z"/></g></svg>
     link: https://github.com/BDHU/minimalist
+
+# https://github.com/github/pages-gem/issues/399#issuecomment-301827749
+# When running locally, we run into the following error —
+# GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
+# adding this avoids it
+github: [metadata]


### PR DESCRIPTION
Loved the theme and wanted to try it locally but ran into 2 issues —
1. "GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data."
   - adding `github: [metadata]` to the `_config.yml` fixes that, per https://github.com/github/pages-gem/issues/399#issuecomment-301827749
2. "`require': cannot load such file -- webrick"
   - running `bundle add webrick` fixes that, as suggested here — https://github.com/jekyll/jekyll/issues/8523#issuecomment-751409319 and accordingly added it to the `Gemfile`