### PR TITLE
fixed syntax highlight issue in dark mode

### DIFF
--- a/_sass/rouge-github.scss
+++ b/_sass/rouge-github.scss
@@ -203,7 +203,8 @@
   color: #008080;
 }
 .highlight .ow {
-  color: #000000;
+  // color: #000000;
+  color: var(--clr-code-bold-text);
   font-weight: bold;
 }
 .highlight .o {


### PR DESCRIPTION
When switched to dark mode, some keywords (like `in`) will be hidden in the background colour, due to some small issue in the `rouge-github.scss`.